### PR TITLE
laravel5.6删除了Illuminate\Contracts\Logging\Log接口。“因为与 Psr\Log\LoggerIn…

### DIFF
--- a/src/Writer.php
+++ b/src/Writer.php
@@ -3,12 +3,11 @@
 namespace Lokielse\LaravelSLS;
 
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Contracts\Logging\Log as LogContract;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Psr\Log\LoggerInterface as PsrLoggerInterface;
 
-class Writer implements LogContract, PsrLoggerInterface
+class Writer implements PsrLoggerInterface
 {
 
     /**


### PR DESCRIPTION
…terface 完全重复， 这个接口已经被移除。你应该用 Psr\Log\LoggerInterface 接口来代替。”
https://laravel-china.org/docs/laravel/5.6/upgrade/1350
![image](https://user-images.githubusercontent.com/22931775/50135464-3740f300-02cf-11e9-84d3-bdd1f8ffe647.png)
